### PR TITLE
implement entity id attr pick-up mech and fix #31

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -32,4 +32,4 @@ jobs:
           python -m pip install black
           python -m pip install .
       - name: Code style check
-        run: python -m black --check src/
+        run: black --check src/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,5 +23,5 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python -m build --sdist --wheel --outdir dist/ .
-          python -m twine upload dist/*
+          build --sdist --wheel --outdir dist/ .
+          twine upload dist/*

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -23,8 +23,7 @@ jobs:
       matrix:
         #os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, macos-latest]
-        #python-version: ['3.6', '3.7', '3.8', '3.9']
-        python-version: ['3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         exclude:
           - os: macos-latest
             python-version: '3.9' # firepit/issues/7

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         #os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        #python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.9']
         exclude:
           - os: macos-latest
             python-version: '3.9' # firepit/issues/7
@@ -40,4 +41,4 @@ jobs:
           python -m pip install pytest
           python -m pip install .
       - name: Unit testing
-        run: python -m pytest
+        run: pytest -vv

--- a/src/kestrel/codegen/commands.py
+++ b/src/kestrel/codegen/commands.py
@@ -230,10 +230,8 @@ def get(stmt, session):
         output = _output
 
         if session.config["prefetch"]["get"] and len(_output):
-
             prefetch_ret_var_name = return_var_name + "_prefetch"
-
-            pattern_pf = _prefetch(
+            prefetch_ret_entity_table = _prefetch(
                 return_type,
                 prefetch_ret_var_name,
                 local_var_name,
@@ -245,20 +243,14 @@ def get(stmt, session):
                 session.session_id,
                 session.data_source_manager,
             )
+        else:
+            prefetch_ret_entity_table = None
 
-            if pattern_pf:
-                # this is a fix when the unique identifier in
-                # `kestrel.codegen.relations.stix_2_0_identical_mapping` is
-                # missing, especially for process.
-
-                # TODO: this or_pattern() code can be removed when we have
-                # better logic of unique identifier of entities.
-
-                full_pat = or_patterns([pattern, pattern_pf])
-                session.store.extract(return_var_name, return_type, None, full_pat)
-                output = new_var(
-                    session.store, return_var_name, [], stmt, session.symtable
-                )
+        if prefetch_ret_entity_table:
+            session.store.merge(return_var_name, [local_var_name, prefetch_ret_entity_table])
+            output = new_var(session.store, return_var_name, [], stmt, session.symtable)
+        else:
+            output = new_var(session.store, local_var_name, [], stmt, session.symtable)
 
     else:
         raise KestrelInternalError(f"unknown type of source in {str(stmt)}")
@@ -370,9 +362,10 @@ def find(stmt, session):
 
         # Second, prefetch all records of the entities and associated entities
         if session.config["prefetch"]["find"] and len(_output) and _output.data_source:
-            if _prefetch(
+            prefetch_ret_var_name = return_var_name + "_prefetch"
+            prefetch_ret_entity_table = _prefetch(
                 return_type,
-                return_var_name,
+                prefetch_ret_var_name,
                 local_var_name,
                 time_range,
                 start_offset,
@@ -381,10 +374,15 @@ def find(stmt, session):
                 session.store,
                 session.session_id,
                 session.data_source_manager,
-            ):
-                output = new_var(
-                    session.store, return_var_name, [], stmt, session.symtable
-                )
+            )
+        else:
+            prefetch_ret_entity_table = None
+
+        if prefetch_ret_entity_table:
+            session.store.merge(return_var_name, [local_var_name, prefetch_ret_entity_table])
+            output = new_var(session.store, return_var_name, [], stmt, session.symtable)
+        else:
+            output = new_var(session.store, local_var_name, [], stmt, session.symtable)
 
     return output, None
 
@@ -487,27 +485,21 @@ def _prefetch(
         session_id (str): session ID.
 
     Returns:
-        [str]: pattern if the prefetch is performed.
+        str: the entity table in store if the prefetch is performed else None.
     """
-    # only need to return bool in the future
 
-    pattern_body = compile_identical_entity_search_pattern(return_type, input_var_name)
+    pattern_body = compile_identical_entity_search_pattern(input_var_name, symtable[input_var_name])
 
-    if pattern_body:
-        # this may fail if the attribute in `stix_2_0_identical_mapping` does not exists
-        # this is important since STIX does not have any mandatory attributes for process/file
-        remote_pattern = build_pattern(
-            pattern_body, time_range, start_offset, end_offset, symtable, store
-        )
+    remote_pattern = build_pattern(pattern_body, time_range, start_offset, end_offset, symtable, store)
 
-        if remote_pattern:
-            data_source = symtable[input_var_name].data_source
-            resp = ds_manager.query(data_source, remote_pattern, session_id)
-            query_id = resp.load_to_store(store)
+    if remote_pattern:
+        data_source = symtable[input_var_name].data_source
+        resp = ds_manager.query(data_source, remote_pattern, session_id)
+        query_id = resp.load_to_store(store)
 
-            # build the return_var_name view in store
-            store.extract(return_var_name, return_type, None, remote_pattern)
+        # build the return_var_name view in store
+        store.extract(return_var_name, return_type, query_id, remote_pattern)
 
-            return remote_pattern
+        return return_var_name
 
     return None

--- a/src/kestrel/codegen/commands.py
+++ b/src/kestrel/codegen/commands.py
@@ -247,7 +247,9 @@ def get(stmt, session):
             prefetch_ret_entity_table = None
 
         if prefetch_ret_entity_table:
-            session.store.merge(return_var_name, [local_var_name, prefetch_ret_entity_table])
+            session.store.merge(
+                return_var_name, [local_var_name, prefetch_ret_entity_table]
+            )
             output = new_var(session.store, return_var_name, [], stmt, session.symtable)
         else:
             output = new_var(session.store, local_var_name, [], stmt, session.symtable)
@@ -379,7 +381,9 @@ def find(stmt, session):
             prefetch_ret_entity_table = None
 
         if prefetch_ret_entity_table:
-            session.store.merge(return_var_name, [local_var_name, prefetch_ret_entity_table])
+            session.store.merge(
+                return_var_name, [local_var_name, prefetch_ret_entity_table]
+            )
             output = new_var(session.store, return_var_name, [], stmt, session.symtable)
         else:
             output = new_var(session.store, local_var_name, [], stmt, session.symtable)
@@ -488,9 +492,13 @@ def _prefetch(
         str: the entity table in store if the prefetch is performed else None.
     """
 
-    pattern_body = compile_identical_entity_search_pattern(input_var_name, symtable[input_var_name])
+    pattern_body = compile_identical_entity_search_pattern(
+        input_var_name, symtable[input_var_name]
+    )
 
-    remote_pattern = build_pattern(pattern_body, time_range, start_offset, end_offset, symtable, store)
+    remote_pattern = build_pattern(
+        pattern_body, time_range, start_offset, end_offset, symtable, store
+    )
 
     if remote_pattern:
         data_source = symtable[input_var_name].data_source

--- a/src/kestrel/codegen/relations.py
+++ b/src/kestrel/codegen/relations.py
@@ -8,6 +8,13 @@ for more details.
 
 import logging
 
+from firepit.query import (
+    Query,
+    Projection,
+    Table,
+    Unique
+)
+
 _logger = logging.getLogger(__name__)
 
 stix_2_0_ref_mapping = {
@@ -61,8 +68,9 @@ stix_2_0_ref_mapping = {
     ("windows-service-ext", "loaded", "user-account"): (["creator_user_ref"], True),
 }
 
+# the first available attribute will be used to uniquely identify the entity
 stix_2_0_identical_mapping = {
-    # entity-type: combination of attributes used for identical entity lookup
+    # entity-type: id attributes candidates
     "directory": ("path",),
     "domain-name": ("value",),
     "email-addr": ("value",),
@@ -74,7 +82,7 @@ stix_2_0_identical_mapping = {
     # `pid` is optional in STIX standard
     # `first_observed` cannot be used since it may be wrong (derived from observation)
     # `command_line` or `name` may not be in data and cannot be used
-    "process": ("pid",),
+    "process": ("pid", "name"),
     "software": ("name",),
     "url": ("value",),
     "user-account": ("user_id",),  # optional in STIX standard
@@ -102,6 +110,31 @@ all_relations = list(
 all_entity_types = list(
     set([x[ind] for x in stix_2_0_ref_mapping.keys() for ind in [0, 2]])
 )
+
+
+def get_entity_id_attribute(variable):
+    # this function should always return something
+    # if no entity id attribute found, fall back to record "id" by default
+    # this works for:
+    #   - no appriparite identifier attribute found given specific data
+    #   - "network-traffic" (not in stix_2_0_identical_mapping)
+    id_attr = "id"
+
+    if variable.type in stix_2_0_identical_mapping:
+        available_attributes = variable.store.columns(variable.entity_table)
+        for attr in stix_2_0_identical_mapping[variable.type]:
+            if attr in available_attributes:
+                query = Query()
+                query.append(Table(variable.entity_table))
+                query.append(Projection([attr]))
+                query.append(Unique())
+                rows = variable.store.run_query(query).fetchall()
+                all_values = [row[attr] for row in rows if row[attr]]
+                if all_values:
+                    id_attr = attr
+                    break
+
+    return id_attr
 
 
 def are_entities_associated_with_x_ibm_event(entity_types):
@@ -133,15 +166,10 @@ def compile_specific_relation_to_pattern(
     return pattern
 
 
-def compile_identical_entity_search_pattern(entity_type, var_name):
-    comp_exps = []
-    if entity_type in stix_2_0_identical_mapping:
-        for attribute in stix_2_0_identical_mapping[entity_type]:
-            comp_exps.append(f"{entity_type}:{attribute} = {var_name}.{attribute}")
-        pattern = "[" + " AND ".join(comp_exps) + "]"
-        _logger.debug(f"identical entity search pattern compiled: {pattern}")
-    else:
-        pattern = None
+def compile_identical_entity_search_pattern(var_name, var_struct):
+    attribute = get_entity_id_attribute(var_struct)
+    pattern = f"[{var_struct.type}:{attribute} = {var_name}.{attribute}]"
+    _logger.debug(f"identical entity search pattern compiled: {pattern}")
     return pattern
 
 

--- a/src/kestrel/codegen/relations.py
+++ b/src/kestrel/codegen/relations.py
@@ -8,12 +8,7 @@ for more details.
 
 import logging
 
-from firepit.query import (
-    Query,
-    Projection,
-    Table,
-    Unique
-)
+from firepit.query import Query, Projection, Table, Unique
 
 _logger = logging.getLogger(__name__)
 

--- a/src/kestrel/codegen/summary.py
+++ b/src/kestrel/codegen/summary.py
@@ -37,7 +37,9 @@ def gen_variable_summary(var_name, var_struct):
 
     is_from_direct_datasource = False
     var_birth_cmd = var_struct.birth_statement["command"]
-    if var_birth_cmd == "find" or (var_birth_cmd == "get" and "datasource" in var_struct.birth_statement):
+    if var_birth_cmd == "find" or (
+        var_birth_cmd == "get" and "datasource" in var_struct.birth_statement
+    ):
         is_from_direct_datasource = True
 
     for table in var_struct.store.tables():

--- a/tests/test_command_find.py
+++ b/tests/test_command_find.py
@@ -22,7 +22,6 @@ procs = FIND process CREATED conns
     correct_dict = {
         "display": "execution summary",
         "data": {
-            "execution time": 1,
             "variables updated": [
                 {
                     "VARIABLE": "conns",
@@ -47,4 +46,5 @@ procs = FIND process CREATED conns
         },
     }
     output_dict = summaries[0].to_dict()
+    del output_dict["data"]["execution time"]
     assert output_dict == correct_dict

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -30,7 +30,6 @@ newvar = NEW [ {"type": "process", "name": "cmd.exe", "pid": "123"}
     correct_dict = {
         "display": "execution summary",
         "data": {
-            "execution time": 1,
             "variables updated": [
                 {
                     "VARIABLE": "newvar",
@@ -44,6 +43,7 @@ newvar = NEW [ {"type": "process", "name": "cmd.exe", "pid": "123"}
         },
     }
     output_dict = d[0].to_dict()
+    del output_dict["data"]["execution time"]
     assert output_dict == correct_dict
 
 
@@ -61,7 +61,6 @@ exp = GET process from newvar WHERE [process:name = 'explorer.exe']
     correct_dict = {
         "display": "execution summary",
         "data": {
-            "execution time": 1,
             "variables updated": [
                 {
                     "VARIABLE": "newvar",
@@ -82,4 +81,5 @@ exp = GET process from newvar WHERE [process:name = 'explorer.exe']
         },
     }
     output_dict = d[0].to_dict()
+    del output_dict["data"]["execution time"]
     assert output_dict == correct_dict


### PR DESCRIPTION
The PR fully addresses #31 and partially addresses #32.

1. implement a new function `get_entity_id_attribute()` in `src/kestrel/codegen/relations.py` to compute the appropriate attribute used as identifier attribute for entities.
2. update `src/kestrel/codegen/commands.py` to use `get_entity_id_attribute()`.
3. replace the `or_pattern()` for post-prefetch merge in `src/kestrel/codegen/commands.py` with `firepit.merge()` (partially address #32).
4. update `get_variable_entity_count()` in `src/kestrel/codegen/summary.py` to use `get_entity_id_attribute()`.
5. update `_get_variable_query_ids()` in `src/kestrel/codegen/summary.py` since merged variable in `firepit` do not have `__membership` records.
6. update `gen_variable_summary()` in `src/kestrel/codegen/summary.py` to only give cached records when there is a data source query.