### PR TITLE
Infer scheme if omitted and only 1 is available

### DIFF
--- a/src/kestrel/analytics/manager.py
+++ b/src/kestrel/analytics/manager.py
@@ -27,7 +27,10 @@ class AnalyticsManager:
         return self.scheme_to_interface[scheme].list_analytics()
 
     def execute(self, uri, argument_variables, session_id, parameters):
-        scheme = uri.split("://")[0]
+        scheme, _, path = uri.rpartition("://")
+        if not scheme and len(self.schemes()) == 1:
+            # If there's only 1 and use didn't specify, use it
+            scheme = self.schemes()[0]
         scheme = scheme.lower()
         if scheme not in self.scheme_to_interface:
             raise AnalyticsInterfaceNotFound(scheme)

--- a/src/kestrel/datasource/manager.py
+++ b/src/kestrel/datasource/manager.py
@@ -30,7 +30,10 @@ class DataSourceManager:
         return self.scheme_to_interface[scheme].list_data_sources()
 
     def query(self, uri, pattern, session_id):
-        scheme = uri.split("://")[0]
+        scheme, _, path = uri.rpartition("://")
+        if not scheme and len(self.schemes()) == 1:
+            # If there's only 1 and use didn't specify, use it
+            scheme = self.schemes()[0]
         scheme = scheme.lower()
         if scheme not in self.scheme_to_interface:
             raise DataSourceInterfaceNotFound(scheme)


### PR DESCRIPTION
If you only have 1 scheme (datasource or analytics), it would be nice if you didn't have to specify it. 
In the future, we could also add a "default" scheme to the config file, and use that if the scheme is omitted.
Another future possibility is to walk the list of all choices for each scheme and use the first match.