### PR TITLE
Add new InvalidAnalyticsInput exception

### DIFF
--- a/src/kestrel/exceptions.py
+++ b/src/kestrel/exceptions.py
@@ -232,7 +232,7 @@ class ConflictingAnalyticsInterfaceScheme(KestrelException):
 
 class InvalidAnalyticsInput(KestrelException):
     def __init__(self, type_received, types_expected):
-        typelist = ', '.join(types_expected)
+        typelist = ", ".join(types_expected)
         super().__init__(
             f'received unsupported type "{type_received}"; expected one of "{typelist}"'
         )

--- a/src/kestrel/exceptions.py
+++ b/src/kestrel/exceptions.py
@@ -228,3 +228,11 @@ class ConflictingAnalyticsInterfaceScheme(KestrelException):
             f'conflicting analytics interface scheme "{scheme}" between "{itf_a.__module__}" and "{itf_b.__module__}"',
             "uninstall one of the analytics interfaces",
         )
+
+
+class InvalidAnalyticsInput(KestrelException):
+    def __init__(self, type_received, types_expected):
+        typelist = ', '.join(types_expected)
+        super().__init__(
+            f'received unsupported type "{type_received}"; expected one of "{typelist}"'
+        )


### PR DESCRIPTION
Analytics interfaces can raise this exception if they provide a method for type checking.  For example, the docker interface could use docker image labels to specify the list of types expected.