### PR TITLE
fix two issues for complete FIND command

### DIFF
--- a/src/kestrel/session.py
+++ b/src/kestrel/session.py
@@ -370,6 +370,7 @@ class Session(AbstractContextManager):
         prefix = code[:cursor_pos]
         words = prefix.split(" ")
         last_word = words[-1]
+        last_char = prefix[-1]
         _logger.debug('code="%s" prefix="%s" last_word="%s"', code, prefix, last_word)
 
         if "START" in prefix or "STOP" in prefix:
@@ -439,17 +440,16 @@ class Session(AbstractContextManager):
                             tmp.extend(get_entity_types())
                         else:
                             tmp.extend(all_relations)
-                    elif token == "REVERSED":
+                    elif token == "BY":
                         tmp.append("BY")
-                        prev_word = words[-2] if len(words) >= 2 else ""
-                        _logger.debug("prev_word = %s", prev_word)
-                        if prev_word in all_relations:
-                            pass
-                        elif prev_word in varnames:
-                            pass
-                        elif last_word not in varnames:
-                            # Must be FIND and not GROUP
-                            tmp.extend(all_relations)
+                    elif token == "REVERSED":
+                        if last_char == " ":
+                            tmp.append("BY")
+                        else:
+                            # "procs = FIND process l" will expect ['REVERSED', 'VARIABLE']
+                            # override results from the case of VARIABLE
+                            tmp = all_relations
+                            break
                     elif token == "FUNCNAME":
                         tmp.extend(AGG_FUNCS)
                     elif token == "TRANSFORM":

--- a/src/kestrel/syntax/kestrel.lark
+++ b/src/kestrel/syntax/kestrel.lark
@@ -44,11 +44,11 @@ find: "find"i ENTITY_TYPE RELATION (REVERSED)? VARIABLE (starttime endtime)?
 
 apply: "apply"i ANALYTICS "on"i variables ("with"i anaparams)?
 
-join: "join"i VARIABLE "," VARIABLE ("by"i STIXPATH "," STIXPATH)?
+join: "join"i VARIABLE "," VARIABLE (BY STIXPATH "," STIXPATH)?
 
-sort: "sort"i VARIABLE "by"i STIXPATH (ASC|DESC)?
+sort: "sort"i VARIABLE BY STIXPATH (ASC|DESC)?
 
-group: "group"i VARIABLE "by"i path_list ("with"i agg_list)?
+group: "group"i VARIABLE BY path_list ("with"i agg_list)?
 
 load: "load"i DUMPPATH ("as"i ENTITY_TYPE)?
 
@@ -63,7 +63,7 @@ expression: transform where_clause? attr_clause? sort_clause? limit_clause? offs
 
 where_clause: "where"i condition
 attr_clause: "attr"i STIXPATHS
-sort_clause: "sort"i "by"i STIXPATH (ASC|DESC)?
+sort_clause: "sort"i BY STIXPATH (ASC|DESC)?
 limit_clause: "limit"i INT
 offset_clause: "offset"i INT
 
@@ -125,6 +125,7 @@ DUMPPATH: PATH
 ASC: "asc"i
 DESC: "desc"i
 REVERSED: "by"i
+BY: "by"i
 COMMENT: /#.*/
 URI: PATH
 

--- a/src/kestrel/syntax/parser.py
+++ b/src/kestrel/syntax/parser.py
@@ -306,8 +306,10 @@ def _third(args):
 def _fourth(args):
     return args[3].value
 
+
 def _fifth(args):
     return args[3].value
+
 
 def _last(args):
     return args[-1].value

--- a/src/kestrel/syntax/parser.py
+++ b/src/kestrel/syntax/parser.py
@@ -119,21 +119,21 @@ class _PostParsing(Transformer):
                 "command": "join",
                 "input": _first(args),
                 "input_2": _second(args),
-                "path": _third(args),
-                "path_2": _fourth(args),
+                "path": _fourth(args),
+                "path_2": _fifth(args),
             }
         else:
             return {"command": "join", "input": _first(args), "input_2": _second(args)}
 
     def group(self, args):
         # args[1] was already transformed by path_list/valuelist
-        cols = _normalize_paths(args[1])
+        cols = _normalize_paths(args[2])
         result = {
             "command": "group",
             "paths": cols,
             "input": _extract_var(args, self.default_variable),
         }
-        aggregations = args[2] if len(args) > 2 else None
+        aggregations = args[3] if len(args) > 3 else None
         if aggregations:
             result["aggregations"] = aggregations
         return result
@@ -306,6 +306,8 @@ def _third(args):
 def _fourth(args):
     return args[3].value
 
+def _fifth(args):
+    return args[3].value
 
 def _last(args):
     return args[-1].value

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -51,9 +51,10 @@ def a_session():
         #("procs = FIND process ", {"created", "loaded", "linked"}),
         ("procs = FIND process ", all_relations),
         ("procs = FIND process l", {"oaded", "inked"}),
-        ("procs = FIND process c", {"reated", "ontained", "onns"}),  # FIXME: shouldn't suggest var here
+        ("procs = FIND process c", {"reated", "ontained"}),
         ("procs = FIND process created ", {"conns", "_", "BY"}),
         ("procs = FIND process created BY ", {"conns", "_"}),
+        ("procs2 = SORT procs ", {"BY"}),
         ("grps = GR", {"OUP"}),
         ("grps = GROUP ", {"conns", "_"}),
         ("grps = GROUP conns ", {"BY"}),


### PR DESCRIPTION
1. the terminal `"by"i` is now differentiated between `FIND` and `SORT`/`GROUP`
2. now variables such as `conns` are not in the completion of `FIND process c`