### PR TITLE
Restrict assign and merge command syntax

### DIFF
--- a/src/kestrel/session.py
+++ b/src/kestrel/session.py
@@ -469,7 +469,10 @@ class Session(AbstractContextManager):
                     elif token.startswith("__ANON"):
                         continue
                     elif token == "EQUAL":
-                        tmp.append("=")
+                        if last_word:
+                            tmp.extend(varnames)
+                        else:
+                            tmp.append("=")
                     elif token in keywords and last_word.islower():
                         # keywords has both upper and lower case
                         tmp.append(token.lower())

--- a/src/kestrel/session.py
+++ b/src/kestrel/session.py
@@ -300,14 +300,17 @@ class Session(AbstractContextManager):
                 self.config["language"]["default_sort_order"],
             )
         except lark.UnexpectedEOF as err:
+            # use `err.expected` as used in lark.exceptions.UnexpectedEOF
             raise KestrelSyntaxError(
                 err.line, err.column, "end of line", "", err.expected
             )
         except lark.UnexpectedCharacters as err:
+            # use `err.allowed` as used in lark.exceptions.UnexpectedCharacters
             raise KestrelSyntaxError(
                 err.line, err.column, "character", err.char, err.allowed
             )
         except lark.UnexpectedToken as err:
+            # use `err.accepts or err.expected` as used in lark.exceptions.UnexpectedToken
             raise KestrelSyntaxError(
                 err.line, err.column, "token", err.token, err.accepts or err.expected
             )

--- a/src/kestrel/syntax/kestrel.lark
+++ b/src/kestrel/syntax/kestrel.lark
@@ -12,16 +12,18 @@ statement: assignment
          | command_no_result
          
 // If no VARIABLE is given, default to _ in post-parsing
-assignment: (VARIABLE "=")? command_with_result
+// For assign or merge, the result variable is required
+// This eliminates meaningless huntflows like `var1 var2 var3`
+assignment: VARIABLE "=" expression
+          | VARIABLE "=" VARIABLE ("+" VARIABLE)+
+          | (VARIABLE "=")? command_with_result
 
 // "?" at the beginning will inline command
-?command_with_result: assign
-                    | find
+?command_with_result: find
                     | get
                     | group
                     | join
                     | load
-                    | merge
                     | new
                     | sort
 
@@ -29,8 +31,6 @@ assignment: (VARIABLE "=")? command_with_result
                   | disp
                   | info
                   | save
-
-assign: expression
 
 //
 // All commands
@@ -45,8 +45,6 @@ group: "GROUP"i VARIABLE BY grp_spec ("WITH"i agg_list)?
 join: "JOIN"i VARIABLE "," VARIABLE (BY ATTRIBUTE "," ATTRIBUTE)?
 
 load: "LOAD"i stdpath ("AS"i ENTITY_TYPE)?
-
-merge: VARIABLE ("+" VARIABLE)+
 
 new: "NEW"i ENTITY_TYPE? VAR_DATA
 

--- a/src/kestrel/syntax/parser.py
+++ b/src/kestrel/syntax/parser.py
@@ -89,14 +89,24 @@ class _KestrelT(Transformer):
         return stmt
 
     def assignment(self, args):
-        stmt = args[1] if len(args) == 2 else args[0]
-        stmt["output"] = self._extract_var(args)
+        if len(args) > 2:
+            variables = self._extract_vars(args)
+            stmt = {
+                "command": "merge",
+                "output": variables[0],
+                "inputs": variables[1:]
+            }
+        elif len(args) == 2:
+            stmt = args[1]
+            # the tree is already processed, and the only thing left is the result variable
+            # get it using `self._extract_var()`
+            stmt["output"] = self._extract_var(args)
+            if "command" not in stmt:
+                stmt["command"] = "assign"
+        else:
+            stmt = args[0]
+            stmt["output"] = self.default_variable
         return stmt
-
-    def assign(self, args):
-        packet = args[0]  # Already transformed in expression method below
-        packet["command"] = "assign"
-        return packet
 
     def merge(self, args):
         return {

--- a/src/kestrel/syntax/parser.py
+++ b/src/kestrel/syntax/parser.py
@@ -108,12 +108,6 @@ class _KestrelT(Transformer):
             stmt["output"] = self.default_variable
         return stmt
 
-    def merge(self, args):
-        return {
-            "command": "merge",
-            "inputs": self._extract_vars(args),
-        }
-
     def info(self, args):
         return {"command": "info", "input": self._extract_var(args)}
 

--- a/src/kestrel/syntax/parser.py
+++ b/src/kestrel/syntax/parser.py
@@ -91,11 +91,7 @@ class _KestrelT(Transformer):
     def assignment(self, args):
         if len(args) > 2:
             variables = self._extract_vars(args)
-            stmt = {
-                "command": "merge",
-                "output": variables[0],
-                "inputs": variables[1:]
-            }
+            stmt = {"command": "merge", "output": variables[0], "inputs": variables[1:]}
         elif len(args) == 2:
             stmt = args[1]
             # the tree is already processed, and the only thing left is the result variable

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -51,10 +51,10 @@ def a_session():
     "code, expected",
     [
         ("x", []),  # No suggestions
-        ("x ", {"=", "+"}),
+        ("x ", {"="}),
         ("c", {"onns"}),
         ("conns", [""]),  # Empty string means word is complete
-        ("conns ", {"=", "+"}),
+        ("conns ", {"="}),
         ("disp ", {"conns", "_"} | TRANSFORMS),
         (
             "procs = ",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -55,6 +55,7 @@ def test_undefined_variable(fake_bundle_file):
 
 def test_garbage():
     with Session(debug_mode=True) as session:
-        with pytest.raises(VariableNotExist) as e:
+        with pytest.raises(KestrelSyntaxError) as einfo:
             session.execute("garbage")
-        print(e)
+        err = einfo.value
+        assert err.expected == ["EQUAL"]


### PR DESCRIPTION
The existing `assign` and `merge` commands allow omitted result variable, so the following huntflow is currently legal:
```
DISP var1 var2 var3 var4
```
Which basically is
```
DISP var1
_ = var2
_ = var3
_ = var4
```
This is not meaningful, which may confuse users, and it fails existing auto-completion.

This PR restricts `assign` and `merge` commands so they need to have a result variable. This is a preparation step for auto-completion upgrade. Now a variable alone is not a complete Kestrel statement anymore, so `varx` will expect `=`.