### PR TITLE
Dialect support for stix-shifter connector

### DIFF
--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -26,6 +26,9 @@ will load profiles from 3 places (the later will override the former):
                     port: 9200
                     selfSignedCert: false # this means do NOT check cert
                     indices: host101
+                    options:  # options section only needed when using a dialect
+                        dialects: # for more info about dialects, see https://github.com/opensecurityalliance/stix-shifter/blob/develop/OVERVIEW.md
+                          - beats
                 config:
                     auth:
                         id: VuaCfGcBCdbkQm-e5aOx

--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -27,7 +27,7 @@ will load profiles from 3 places (the later will override the former):
                     selfSignedCert: false # this means do NOT check cert
                     indices: host101
                     options:  # options section only needed when using a dialect
-                        dialects: # for more info about dialects, see https://github.com/opensecurityalliance/stix-shifter/blob/develop/OVERVIEW.md
+                        dialects: # for more info about dialects, see https://github.com/opencybersecurityalliance/stix-shifter/blob/develop/OVERVIEW.md
                           - beats
                 config:
                     auth:


### PR DESCRIPTION
This addresses issue https://github.com/opencybersecurityalliance/kestrel-lang/issues/270  

We have established that the capability to specify a dialect in a STIX shifter profiler is already there, and enhanced a profile example in the documentation to show how to add a dialect to that profile.