### PR TITLE
stix-shifter interface config minor upgrade

### DIFF
--- a/docs/overview/hunting.rst
+++ b/docs/overview/hunting.rst
@@ -1,5 +1,5 @@
 Cyberthreat hunting is the planning and developing of threat discovery
-procedures on against new and customized advanced persistent threats (APT).
+procedures against new and customized advanced persistent threats (APT).
 Cyberthreat hunting is comprised of several activities such as:
 
 #. Understanding the security measurements in the target environment.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ install_requires =
     lark>=1.1.5
     pyarrow>=5.0.0
     docker>=5.0.0
-    stix-shifter>=4.6.0,<5.0.0
-    stix-shifter-utils>=4.6.0,<5.0.0
+    stix-shifter>=4.6.1,<5.0.0
+    stix-shifter-utils>=4.6.1,<5.0.0
     firepit>=2.3.12
     typeguard
 tests_require =

--- a/src/kestrel_datasource_stixshifter/config.py
+++ b/src/kestrel_datasource_stixshifter/config.py
@@ -133,7 +133,11 @@ def get_datasource_from_profiles(profile_name, profiles):
                 "stixshifter",
                 f'invalid {profile_name} configuration section: no "auth" field',
             )
-    return connector_name, connection, configuration
+        if "options" in connection:
+            # need to remove the non-stix-shifter field "retrieval_batch_size" to avoid stix-shifter error
+            retrieval_batch_size = connection["options"].pop("retrieval_batch_size", RETRIEVAL_BATCH_SIZE)
+            _logger.debug(f"retrieval_batch_size set to: {retrieval_batch_size}")
+    return connector_name, connection, configuration, retrieval_batch_size
 
 
 def load_profiles():

--- a/src/kestrel_datasource_stixshifter/config.py
+++ b/src/kestrel_datasource_stixshifter/config.py
@@ -135,7 +135,9 @@ def get_datasource_from_profiles(profile_name, profiles):
             )
         if "options" in connection:
             # need to remove the non-stix-shifter field "retrieval_batch_size" to avoid stix-shifter error
-            retrieval_batch_size = connection["options"].pop("retrieval_batch_size", RETRIEVAL_BATCH_SIZE)
+            retrieval_batch_size = connection["options"].pop(
+                "retrieval_batch_size", RETRIEVAL_BATCH_SIZE
+            )
             _logger.debug(f"retrieval_batch_size set to: {retrieval_batch_size}")
     return connector_name, connection, configuration, retrieval_batch_size
 

--- a/src/kestrel_datasource_stixshifter/config.py
+++ b/src/kestrel_datasource_stixshifter/config.py
@@ -133,12 +133,14 @@ def get_datasource_from_profiles(profile_name, profiles):
                 "stixshifter",
                 f'invalid {profile_name} configuration section: no "auth" field',
             )
-        if "options" in connection:
+
+        retrieval_batch_size = RETRIEVAL_BATCH_SIZE
+        if "options" in connection and "retrieval_batch_size" in connection["options"]:
             # need to remove the non-stix-shifter field "retrieval_batch_size" to avoid stix-shifter error
-            retrieval_batch_size = connection["options"].pop(
-                "retrieval_batch_size", RETRIEVAL_BATCH_SIZE
+            retrieval_batch_size = connection["options"].pop("retrieval_batch_size")
+            _logger.debug(
+                f"profile-loaded retrieval_batch_size: {retrieval_batch_size}"
             )
-            _logger.debug(f"retrieval_batch_size set to: {retrieval_batch_size}")
     return connector_name, connection, configuration, retrieval_batch_size
 
 

--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -115,7 +115,6 @@ from kestrel.datasource import ReturnFromFile
 from kestrel.exceptions import DataSourceError, DataSourceManagerInternalError
 from kestrel_datasource_stixshifter.connector import check_module_availability
 from kestrel_datasource_stixshifter.config import (
-    RETRIEVAL_BATCH_SIZE,
     get_datasource_from_profiles,
     load_options,
     load_profiles,
@@ -150,6 +149,7 @@ class StixShifterInterface(AbstractDataSourceInterface):
         # CONFIG command is not supported
         # profiles will be updated according to YAML file and env var
         config["profiles"] = load_profiles()
+
         config["options"] = load_options()
         _logger.debug("fast_translate enabled for: %s", config["options"]["fast_translate"])
 
@@ -174,6 +174,7 @@ class StixShifterInterface(AbstractDataSourceInterface):
                 connector_name,
                 connection_dict,
                 configuration_dict,
+                retrieval_batch_size,
             ) = map(
                 copy.deepcopy, get_datasource_from_profiles(profile, config["profiles"])
             )
@@ -231,10 +232,6 @@ class StixShifterInterface(AbstractDataSourceInterface):
 
                     result_retrieval_offset = 0
                     has_remaining_results = True
-                    try:
-                        retrieval_batch_size = connection_dict["options"]["retrieval_batch_size"]
-                    except KeyError:
-                        retrieval_batch_size = RETRIEVAL_BATCH_SIZE
                     metadata = None
                     while has_remaining_results:
                         result_batch = transmission.results(

--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -151,7 +151,9 @@ class StixShifterInterface(AbstractDataSourceInterface):
         config["profiles"] = load_profiles()
 
         config["options"] = load_options()
-        _logger.debug("fast_translate enabled for: %s", config["options"]["fast_translate"])
+        _logger.debug(
+            "fast_translate enabled for: %s", config["options"]["fast_translate"]
+        )
 
         scheme, _, profile = uri.rpartition("://")
         profiles = profile.split(",")

--- a/tests/test_stixshifter.py
+++ b/tests/test_stixshifter.py
@@ -8,6 +8,8 @@ from kestrel_datasource_stixshifter.connector import (
     check_module_availability,
 )
 
+from kestrel_datasource_stixshifter.config import get_datasource_from_profiles
+
 
 def test_verify_package_origin():
     connectors = ["stix_bundle", "qradar", "elastic_ecs", "splunk"]
@@ -45,6 +47,10 @@ profiles:
             host: elastic.securitylog.company.com
             port: 9200
             indices: host101
+            options:
+                retrieval_batch_size: 10000
+                dialects:
+                    - beats
         config:
             auth:
                 id: profileB
@@ -71,9 +77,11 @@ newvar = NEW [ {"type": "process", "name": "cmd.exe", "pid": "123"}
 
         ss_config = s.config["datasources"]["kestrel_datasource_stixshifter"]
         ss_profiles = ss_config["profiles"]
-        ss_host101_auth = ss_profiles["host101"]["config"]["auth"]
-        assert ss_host101_auth["id"] == "profileA"
-        assert ss_host101_auth["api_key"] == "qwer"
+        connector_name, connection, configuration, retrieval_batch_size = get_datasource_from_profiles("host101", ss_profiles)
+        assert connector_name == "elastic_ecs"
+        assert configuration["auth"]["id"] == "profileA"
+        assert configuration["auth"]["api_key"] == "qwer"
+        assert retrieval_batch_size == 2000
 
         with open(profile_file, "w") as pf:
             pf.write(profileB)
@@ -82,6 +90,8 @@ newvar = NEW [ {"type": "process", "name": "cmd.exe", "pid": "123"}
 
         # need to refresh the pointers since the dict is updated
         ss_profiles = ss_config["profiles"]
-        ss_host101_auth = ss_profiles["host101"]["config"]["auth"]
-        assert ss_host101_auth["id"] == "profileB"
-        assert ss_host101_auth["api_key"] == "asdf"
+        connector_name, connection, configuration, retrieval_batch_size = get_datasource_from_profiles("host101", ss_profiles)
+        assert connector_name == "elastic_ecs"
+        assert configuration["auth"]["id"] == "profileB"
+        assert configuration["auth"]["api_key"] == "asdf"
+        assert retrieval_batch_size == 10000


### PR DESCRIPTION
- Configurable retrieval batch size
- `CONFIG` command ready for "options" section
- Comprehensive return size config example with references