### PR TITLE
fix a stix-shifter interface bug: invalid bundle

### DIFF
--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -197,7 +197,11 @@ class StixShifterInterface(AbstractDataSourceInterface):
             data_path_striped = "".join(filter(str.isalnum, profile))
             ingestfile = ingestdir / f"{i}_{data_path_striped}.json"
 
-            identity = {"id": "identity--" + query_id, "name": connector_name}
+            identity = {
+                "id": "identity--" + query_id,
+                "name": connector_name,
+                "type": "identity",
+            }
             query_metadata = json.dumps(identity)
 
             translation = stix_translation.StixTranslation()


### PR DESCRIPTION
The stix-shifter data source interface generates invalid STIX bundle with the identity SCO without type. Fix the bug so the intermediate STIX bundle generated by the stix-shifter data source interface can be used as data source directly.