### PR TITLE
Hotfix stixshifter 1493 aiohttp

### DIFF
--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -265,6 +265,7 @@ class StixShifterInterface(AbstractDataSourceInterface):
 
                     # run the producer and wait for completion
                     batch_index = await transmission_produce(
+                        connector_name,
                         transmission_queue,
                         transmission,
                         search_id,
@@ -329,7 +330,7 @@ async def transmission_complete(transmission, search_id):
 
 
 async def transmission_produce(
-    transmission_queue, transmission, search_id, retrieval_batch_size, batch_index
+    connector_name, transmission_queue, transmission, search_id, retrieval_batch_size, batch_index
 ):
     result_retrieval_offset = 0
     has_remaining_results = True
@@ -359,7 +360,7 @@ async def transmission_produce(
             )
             if (
                 stix_shifter_error_msg.startswith(
-                    "elastic_ecs connector error => server timeout_error"
+                    f"{connector_name} connector error => server timeout_error"
                 )
                 and not is_retry_cycle
             ):

--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -330,7 +330,12 @@ async def transmission_complete(transmission, search_id):
 
 
 async def transmission_produce(
-    connector_name, transmission_queue, transmission, search_id, retrieval_batch_size, batch_index
+    connector_name,
+    transmission_queue,
+    transmission,
+    search_id,
+    retrieval_batch_size,
+    batch_index,
 ):
     result_retrieval_offset = 0
     has_remaining_results = True

--- a/src/kestrel_datasource_stixshifter/interface.py
+++ b/src/kestrel_datasource_stixshifter/interface.py
@@ -334,6 +334,7 @@ async def transmission_produce(
     result_retrieval_offset = 0
     has_remaining_results = True
     metadata = None
+    is_retry_cycle = False
     while has_remaining_results:
         result_batch = await transmission.results_async(
             search_id, result_retrieval_offset, retrieval_batch_size, metadata
@@ -349,20 +350,27 @@ async def transmission_produce(
                 has_remaining_results = False
             if "metadata" in result_batch:
                 metadata = result_batch["metadata"]
+            is_retry_cycle = False
         else:
             stix_shifter_error_msg = (
                 result_batch["error"]
                 if "error" in result_batch
                 else "details not avaliable"
             )
-            if stix_shifter_error_msg.startswith(
-                "elastic_ecs connector error => server timeout_error"
+            if (
+                stix_shifter_error_msg.startswith(
+                    "elastic_ecs connector error => server timeout_error"
+                )
+                and not is_retry_cycle
             ):
                 # mitigate https://github.com/opencybersecurityalliance/stix-shifter/issues/1493
+                # only give it one retry to mitigate high CPU occupation
+                # otherwise, it could be a real server connection issue
                 # /stix_shifter_utils/stix_transmission/utils/RestApiClientAsync.py
                 _logger.info(
                     f"busy CPU; hit stix-shifter transmission aiohttp connection timeout; retry"
                 )
+                is_retry_cycle = True
             else:
                 raise DataSourceError(
                     f"STIX-shifter transmission.results() failed with message: {stix_shifter_error_msg}"


### PR DESCRIPTION
This is a mitigation, not a final fix. The drawback of this hotfix is that it will let CPU-intensive translation to finish before the next round of transmission, so it nullify the advantage of the pipelining.