### PR TITLE
Quick CSV export fix

### DIFF
--- a/src/kestrel/codegen/data.py
+++ b/src/kestrel/codegen/data.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import pathlib
 import uuid
@@ -55,7 +56,7 @@ def dump_data_to_file(store, input_entity_table, file_path):
     df = pd.DataFrame(input_data)
     dump_format = _get_dump_format(p)
     if dump_format == "csv":
-        df.to_csv(file_path)
+        df.to_csv(file_path, index=False, quoting=csv.QUOTE_NONNUMERIC)
     elif dump_format == "parquet":
         df.to_parquet(file_path)
     elif dump_format == "json":


### PR DESCRIPTION
- exclude dataframe index from CSV output (it adds a blank header field and zero-based row number as the first column, which is pretty useless)
- add QUOTE_NONNUMERIC (I've found his make the CSV more portable in terms of preserving data types)