### PR TITLE
Use environment variables in configuration files

### DIFF
--- a/packages/kestrel_core/src/kestrel/config.py
+++ b/packages/kestrel_core/src/kestrel/config.py
@@ -16,7 +16,7 @@ _logger = logging.getLogger(__name__)
 def load_default_config():
     _logger.debug(f"Loading default config file...")
     default_config = load_data_file("kestrel", "config.yaml")
-    return yaml.safe_load(default_config)
+    return yaml.safe_load(os.path.expandvars(default_config))
 
 
 def load_user_config(config_path_env_var, config_path_default):
@@ -27,7 +27,7 @@ def load_user_config(config_path_env_var, config_path_default):
         try:
             with open(config_path, "r") as fp:
                 _logger.debug(f"User configuration file found: {config_path}")
-                config = yaml.safe_load(fp)
+                config = yaml.safe_load(os.path.expandvars(fp.read()))
         except FileNotFoundError:
             _logger.debug(f"User configuration file not exist.")
     return config

--- a/packages/kestrel_core/tests/test_config.py
+++ b/packages/kestrel_core/tests/test_config.py
@@ -1,4 +1,4 @@
-import kestrel.config.utils as cfg
+import kestrel.config as cfg
 import os
 
 

--- a/packages/kestrel_core/tests/test_config.py
+++ b/packages/kestrel_core/tests/test_config.py
@@ -1,0 +1,60 @@
+import kestrel.config.utils as cfg
+import os
+
+
+def test_env_vars_in_config():
+
+    test_config = """---
+credentials:
+  username: $TEST_USER
+  password: $TEST_PASSWORD
+    """
+    os.environ["TEST_USER"] = "test-user"
+    os.environ["TEST_PASSWORD"] = "test-password"
+    os.environ["KESTREL_CONFIG"] = os.path.join(os.sep, "tmp", "config.yaml")
+
+    with open(os.getenv("KESTREL_CONFIG"), "w") as fp:
+        fp.write(test_config)
+    config = cfg.load_config()
+    assert config["credentials"]["username"] == "test-user"
+    assert config["credentials"]["password"] == "test-password"
+
+
+def test_env_vars_in_config_overwrite():
+
+    test_config = """---
+credentials:
+  username: ${TEST_USER}
+  password: ${TEST_PASSWORD}
+debug:
+  cache_directory_prefix: $KESTREL_CACHE_DIRECTORY_PREFIX
+    """
+    os.environ["TEST_USER"] = "test-user"
+    os.environ["TEST_PASSWORD"] = "test-password"
+    os.environ["KESTREL_CONFIG"] = os.path.join(os.sep, "tmp", "config.yaml")
+    os.environ["KESTREL_CACHE_DIRECTORY_PREFIX"] = "Kestrel2.0-"
+    with open(os.getenv("KESTREL_CONFIG"), "w") as fp:
+        fp.write(test_config)
+    config = cfg.load_config()
+    assert config["credentials"]["username"] == "test-user"
+    assert config["credentials"]["password"] == "test-password"
+    assert config["debug"]["cache_directory_prefix"] == "Kestrel2.0-"
+
+def test_empty_env_var_in_config():
+    test_config = """---
+credentials:
+  username: ${TEST_USER}
+  password: ${TEST_PASSWORD}
+debug:
+  cache_directory_prefix: $I_DONT_EXIST
+    """
+    os.environ["TEST_USER"] = "test-user"
+    os.environ["TEST_PASSWORD"] = "test-password"
+    os.environ["KESTREL_CONFIG"] = os.path.join(os.sep, "tmp", "config.yaml")
+    os.environ["KESTREL_CACHE_DIRECTORY_PREFIX"] = "Kestrel2.0-"
+    with open(os.getenv("KESTREL_CONFIG"), "w") as fp:
+        fp.write(test_config)
+    config = cfg.load_config()
+    assert config["credentials"]["username"] == "test-user"
+    assert config["credentials"]["password"] == "test-password"
+    assert config["debug"]["cache_directory_prefix"] == "$I_DONT_EXIST"


### PR DESCRIPTION
Provide capability to use environment variables in Kestrel configuration files (default or user-defined).  If the environment variable is defined, its value will be injected in the Kestrel configuration.  If the environment variable is not defined, its name will be injected in the Kestrel configuration.  For more details, see `tests/test_config.py`