### PR TITLE
add reference branch to Filter node

### DIFF
--- a/packages-nextgen/kestrel_core/src/kestrel/exceptions.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/exceptions.py
@@ -76,3 +76,7 @@ class InterfaceNotFound(KestrelError):
 
 class InterfaceNameCollision(KestrelError):
     pass
+
+
+class IRGraphMissingNode(KestrelError):
+    pass

--- a/packages-nextgen/kestrel_core/src/kestrel/frontend/compile.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/frontend/compile.py
@@ -238,11 +238,11 @@ class _KestrelT(Transformer):
         filter_node.exp = _map_filter_exp(
             args[0].value, filter_node.exp, self.property_map
         )
-        
+
         # add basic Source and Filter nodes
         source_node = graph.add_node(args[1])
         filter_node = graph.add_node(filter_node, source_node)
-        
+
         # add reference nodes if used in Filter
         _add_reference_branches_for_filter(graph, filter_node)
 

--- a/packages-nextgen/kestrel_core/src/kestrel/ir/instructions.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/ir/instructions.py
@@ -6,6 +6,7 @@ from typing import (
     Mapping,
     List,
     Optional,
+    Iterable,
 )
 from dataclasses import (
     dataclass,
@@ -24,6 +25,8 @@ from kestrel.__future__ import is_python_older_than_minor_version
 from kestrel.ir.filter import (
     FExpression,
     TimeRange,
+    ReferenceValue,
+    get_references_from_exp,
 )
 from kestrel.config.internal import CACHE_INTERFACE_IDENTIFIER
 
@@ -109,6 +112,9 @@ class Return(TransformingInstruction):
 class Filter(TransformingInstruction):
     exp: FExpression
     timerange: TimeRange = field(default_factory=TimeRange)
+
+    def get_references(self) -> Iterable[ReferenceValue]:
+        return get_references_from_exp(self.exp)
 
 
 @dataclass(eq=False)


### PR DESCRIPTION
Upgrade `Filter`, especially `expression` to correctly parse references. Each reference in `where` clause will result in a `Filter -> ProjectAttr -> Reference` branch where `Filter` is the `where` node.

No edge attribute is needed, since any branch from `Filter` that has the first node `ProjectAttr` will be a reference branch. And interfaces can generate SQL/KQL by checking the `ReferenceValue` in the `RefComparison` and link it with a `ProjectAttr` branch as a sub-query.

Note when the graph is given to an interface, all `Reference` nodes should already be replaced/linked by/with `Variable` nodes. This is done when the parser gradually merges the newly parsed part of graph to the existing one.