### PR TITLE
Kestrel2 reference/branch support in sqlite cache

### DIFF
--- a/packages-nextgen/kestrel_core/src/kestrel/cache/sqlite.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/cache/sqlite.py
@@ -140,9 +140,7 @@ class SqliteCache(AbstractCache):
                 #   SAWarning: Coercing Subquery object into a select() for use in IN();
                 #   please pass a select() construct explicitly
                 instruction.resolve_references(
-                    lambda x: self._evaluate_instruction_in_graph(
-                        graph, r2n[x]
-                    ).query
+                    lambda x: self._evaluate_instruction_in_graph(graph, r2n[x]).query
                 )
                 translator.add_instruction(instruction)
 

--- a/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from typing import Callable
 
-from sqlalchemy import and_, column, or_, select, table
+from sqlalchemy import and_, column, or_, select, FromClause
 from sqlalchemy.engine import Compiled, default
 from sqlalchemy.sql.elements import BinaryExpression, BooleanClauseList
 from sqlalchemy.sql.expression import ColumnClause, ColumnOperators
@@ -67,7 +67,7 @@ class SqlTranslator:
         dialect: default.DefaultDialect,
         timefmt: Callable,
         timestamp: str,
-        select_from: str,
+        from_obj: FromClause,
     ):
         # SQLAlchemy Dialect object (e.g. from sqlalchemy.dialects import sqlite; sqlite.dialect())
         self.dialect = dialect
@@ -79,7 +79,7 @@ class SqlTranslator:
         self.timestamp = timestamp
 
         # SQLAlchemy statement object
-        self.query: Select = select().select_from(table(select_from))
+        self.query: Select = select().select_from(from_obj)
 
     def _render_exp(self, exp: BoolExp) -> BooleanClauseList:
         if isinstance(exp.lhs, BoolExp):

--- a/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
@@ -140,6 +140,8 @@ class SqlTranslator:
         method(i)
 
     def result(self) -> Compiled:
+        # TODO: two projections, e.g., ProjectAttrs after ProjectEntity
+
         # If there was no projection, we need to add '*' explicitly
         if len(self.query.selected_columns) == 0:
             self.query = self.query.with_only_columns("*")

--- a/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
@@ -1,3 +1,4 @@
+import logging
 from functools import reduce
 from typing import Callable
 
@@ -26,6 +27,8 @@ from kestrel.ir.instructions import (
     ProjectEntity,
 )
 
+
+_logger = logging.getLogger(__name__)
 
 # SQLAlchemy comparison operator functions
 comp2func = {
@@ -142,3 +145,10 @@ class SqlTranslator:
     def result(self) -> Compiled:
         # TODO: two projections, e.g., ProjectAttrs after ProjectEntity
         return self.query.compile(dialect=self.dialect)
+
+    def result_w_literal_binds(self) -> Compiled:
+        # full SQL query with literal binds showing, i.e., IN [99, 51], not IN [?, ?]
+        # this is for debug display, not used by an sqlalchemy driver to execute
+        return self.query.compile(
+            dialect=self.dialect, compile_kwargs={"literal_binds": True}
+        )

--- a/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/interface/datasource/codegen/sql.py
@@ -79,7 +79,7 @@ class SqlTranslator:
         self.timestamp = timestamp
 
         # SQLAlchemy statement object
-        self.query: Select = select().select_from(from_obj)
+        self.query: Select = select("*").select_from(from_obj)
 
     def _render_exp(self, exp: BoolExp) -> BooleanClauseList:
         if isinstance(exp.lhs, BoolExp):
@@ -141,8 +141,4 @@ class SqlTranslator:
 
     def result(self) -> Compiled:
         # TODO: two projections, e.g., ProjectAttrs after ProjectEntity
-
-        # If there was no projection, we need to add '*' explicitly
-        if len(self.query.selected_columns) == 0:
-            self.query = self.query.with_only_columns("*")
         return self.query.compile(dialect=self.dialect)

--- a/packages-nextgen/kestrel_core/src/kestrel/ir/graph.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/ir/graph.py
@@ -18,7 +18,7 @@ import json
 from kestrel.ir.instructions import (
     Instruction,
     TransformingInstruction,
-    SoleIndegreeTransformingInstruction,
+    SolePredecessorTransformingInstruction,
     IntermediateInstruction,
     SourceInstruction,
     Variable,
@@ -381,7 +381,7 @@ class IRGraph(networkx.DiGraph):
         ps = list(self.predecessors(node))
         pps = [(p, pp) for p in self.predecessors(node) for pp in self.predecessors(p)]
 
-        if isinstance(node, SoleIndegreeTransformingInstruction):
+        if isinstance(node, SolePredecessorTransformingInstruction):
             if len(ps) > 1:
                 raise LargerThanOneIndegreeInstruction()
             else:

--- a/packages-nextgen/kestrel_core/src/kestrel/ir/instructions.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/ir/instructions.py
@@ -86,7 +86,7 @@ class TransformingInstruction(Instruction):
     pass
 
 
-class SoleIndegreeTransformingInstruction(TransformingInstruction):
+class SolePredecessorTransformingInstruction(TransformingInstruction):
     """The translating instruction whose indegree==1"""
 
     pass
@@ -105,7 +105,7 @@ class IntermediateInstruction(Instruction):
 
 
 @dataclass(eq=False)
-class Return(SoleIndegreeTransformingInstruction):
+class Return(SolePredecessorTransformingInstruction):
     """The sink instruction that forces execution
 
     Return is implemented as a TransformingInstruction so it triggers
@@ -131,12 +131,12 @@ class Filter(TransformingInstruction):
 
 
 @dataclass(eq=False)
-class ProjectEntity(SoleIndegreeTransformingInstruction):
+class ProjectEntity(SolePredecessorTransformingInstruction):
     entity_type: str
 
 
 @dataclass(eq=False)
-class ProjectAttrs(SoleIndegreeTransformingInstruction):
+class ProjectAttrs(SolePredecessorTransformingInstruction):
     # mashumaro does not support typing.Iterable, only List
     attrs: List[str]
 
@@ -167,7 +167,7 @@ class DataSource(SourceInstruction):
 
 
 @dataclass(eq=False)
-class Variable(SoleIndegreeTransformingInstruction):
+class Variable(SolePredecessorTransformingInstruction):
     name: str
     # required to dereference a variable that has been created multiple times
     # the variable with the largest version will be used by dereference
@@ -182,7 +182,7 @@ class Reference(IntermediateInstruction):
 
 
 @dataclass(eq=False)
-class Limit(SoleIndegreeTransformingInstruction):
+class Limit(SolePredecessorTransformingInstruction):
     num: int
 
 

--- a/packages-nextgen/kestrel_core/src/kestrel/ir/instructions.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/ir/instructions.py
@@ -28,7 +28,7 @@ from kestrel.ir.filter import (
     TimeRange,
     ReferenceValue,
     get_references_from_exp,
-    fill_references_in_exp,
+    resolve_reference_with_function,
 )
 from kestrel.config.internal import CACHE_INTERFACE_IDENTIFIER
 
@@ -126,8 +126,8 @@ class Filter(TransformingInstruction):
     def get_references(self) -> Iterable[ReferenceValue]:
         return get_references_from_exp(self.exp)
 
-    def fill_references(self, r2v: Mapping[ReferenceValue, Any]):
-        fill_references_in_exp(self.exp, r2v)
+    def resolve_references(self, f: Callable[[ReferenceValue], Any]):
+        resolve_reference_with_function(self.exp, f)
 
 
 @dataclass(eq=False)

--- a/packages-nextgen/kestrel_core/src/kestrel/session.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/session.py
@@ -51,14 +51,17 @@ class Session(AbstractContextManager):
         self.irgraph.update(irgraph_new)
 
         for ret in irgraph_new.get_returns():
-            while ret.id not in self.cache:
+            ret_df = None
+            while ret_df is None:
                 for g in self.irgraph.find_dependent_subgraphs_of_node(ret, self.cache):
                     interface = get_interface_by_name(g.interface, self.interfaces)
                     for iid, df in interface.evaluate_graph(g).items():
                         if g.interface != self.cache.name:
                             self.cache[iid] = df
+                        if iid == ret.id:
+                            ret_df = df
             else:
-                yield self.cache[ret.id]
+                yield ret_df
 
     def do_complete(self, huntflow_block: str, cursor_pos: int):
         """Kestrel code auto-completion.

--- a/packages-nextgen/kestrel_core/tests/test_cache_sqlite.py
+++ b/packages-nextgen/kestrel_core/tests/test_cache_sqlite.py
@@ -127,3 +127,26 @@ browsers = proclist WHERE name IN ("explorer.exe", "firefox.exe", "chrome.exe")
     graph = IRGraphEvaluable(parse_kestrel(stmt))
     c = SqliteCache()
     _ = c.evaluate_graph(graph)
+
+
+def test_eval_filter_with_ref():
+    stmt = """
+proclist = NEW process [ {"name": "cmd.exe", "pid": 123}
+                       , {"name": "explorer.exe", "pid": 99}
+                       , {"name": "firefox.exe", "pid": 201}
+                       , {"name": "chrome.exe", "pid": 205}
+                       ]
+browsers = proclist WHERE name = 'firefox.exe' OR name = 'chrome.exe'
+specials = proclist WHERE pid IN [123, 201]
+p2 = proclist WHERE pid = browsers.pid and name = specials.name
+DISP p2 ATTR name, pid
+"""
+    graph = IRGraphEvaluable(parse_kestrel(stmt))
+    c = SqliteCache()
+    mapping = c.evaluate_graph(graph)
+
+    # check the return is correct
+    rets = graph.get_returns()
+    assert len(rets) == 1
+    df = mapping[rets[0].id]
+    assert df.to_dict("records") == [ {"name": "firefox.exe", "pid": 201} ]

--- a/packages-nextgen/kestrel_core/tests/test_cache_sqlite.py
+++ b/packages-nextgen/kestrel_core/tests/test_cache_sqlite.py
@@ -49,13 +49,6 @@ DISP proclist ATTR name
                                     , {"name": "firefox.exe"}
                                     , {"name": "chrome.exe"}
                                     ]
-    # check whether `proclist` is cached
-    proclist = graph.get_variable("proclist")
-    assert c[proclist.id].to_dict("records") == [ {"name": "cmd.exe", "pid": 123}
-                                                , {"name": "explorer.exe", "pid": 99}
-                                                , {"name": "firefox.exe", "pid": 201}
-                                                , {"name": "chrome.exe", "pid": 205}
-                                                ]
 
 
 def test_eval_new_filter_disp():
@@ -79,20 +72,8 @@ DISP browsers ATTR name, pid
     assert df.to_dict("records") == [ {"name": "firefox.exe", "pid": 201}
                                     , {"name": "chrome.exe", "pid": 205}
                                     ]
-    # check whether `proclist` is cached
-    proclist = graph.get_variable("proclist")
-    assert c[proclist.id].to_dict("records") == [ {"name": "cmd.exe", "pid": 123}
-                                                , {"name": "explorer.exe", "pid": 99}
-                                                , {"name": "firefox.exe", "pid": 201}
-                                                , {"name": "chrome.exe", "pid": 205}
-                                                ]
-    # check whether `browsers` is cached
-    browsers = graph.get_variable("browsers")
-    assert c[browsers.id].to_dict("records") == [ {"name": "firefox.exe", "pid": 201}
-                                                , {"name": "chrome.exe", "pid": 205}
-                                                ]
 
-
+    
 def test_eval_two_returns():
     stmt = """
 proclist = NEW process [ {"name": "cmd.exe", "pid": 123}

--- a/packages-nextgen/kestrel_core/tests/test_interface_datasource_codegen_sql.py
+++ b/packages-nextgen/kestrel_core/tests/test_interface_datasource_codegen_sql.py
@@ -24,7 +24,7 @@ from kestrel.ir.instructions import (
 )
 
 # Use sqlite3 for testing
-from sqlalchemy.dialects import sqlite
+import sqlalchemy
 
 import pytest
 
@@ -68,7 +68,7 @@ def _remove_nl(s):
     ]
 )
 def test_sql_translator(iseq, sql):
-    trans = SqlTranslator(sqlite.dialect(), _time2string, "timestamp", "my_table")
+    trans = SqlTranslator(sqlalchemy.dialects.sqlite.dialect(), _time2string, "timestamp", sqlalchemy.table("my_table"))
     for i in iseq:
         trans.add_instruction(i)
     result = trans.result()

--- a/packages-nextgen/kestrel_core/tests/test_ir_filter.py
+++ b/packages-nextgen/kestrel_core/tests/test_ir_filter.py
@@ -139,7 +139,6 @@ def test_fill_references_in_exp():
     rhs = RefComparison("baz", "=", ReferenceValue("var", "attr"))
     exp = BoolExp(lhs, ExpOp.AND, rhs)
     rs = get_references_from_exp(exp)
-    r2v = {r: 5 for r in rs}
     assert len(r2v) == 1
-    resolve_reference_with_function(exp, lambda x: r2v[x])
+    resolve_reference_with_function(exp, lambda x: 5)
     assert exp.rhs.value == 5

--- a/packages-nextgen/kestrel_core/tests/test_ir_filter.py
+++ b/packages-nextgen/kestrel_core/tests/test_ir_filter.py
@@ -4,7 +4,7 @@ from kestrel.frontend.parser import parse_kestrel
 from kestrel.ir.filter import (
     IntComparison, FloatComparison, StrComparison, ListComparison,
     RefComparison, ReferenceValue, ListOp, NumCompOp, StrCompOp, ExpOp,
-    BoolExp, MultiComp, get_references_from_exp, fill_references_in_exp,
+    BoolExp, MultiComp, get_references_from_exp, resolve_reference_with_function,
 )
 from kestrel.ir.instructions import (
     Filter,
@@ -141,5 +141,5 @@ def test_fill_references_in_exp():
     rs = get_references_from_exp(exp)
     r2v = {r: 5 for r in rs}
     assert len(r2v) == 1
-    fill_references_in_exp(exp, r2v)
+    resolve_reference_with_function(exp, lambda x: r2v[x])
     assert exp.rhs.value == 5

--- a/packages-nextgen/kestrel_core/tests/test_ir_filter.py
+++ b/packages-nextgen/kestrel_core/tests/test_ir_filter.py
@@ -139,6 +139,6 @@ def test_fill_references_in_exp():
     rhs = RefComparison("baz", "=", ReferenceValue("var", "attr"))
     exp = BoolExp(lhs, ExpOp.AND, rhs)
     rs = get_references_from_exp(exp)
-    assert len(r2v) == 1
+    assert len(list(rs)) == 1
     resolve_reference_with_function(exp, lambda x: 5)
     assert exp.rhs.value == 5


### PR DESCRIPTION
This PR implements subquery generation in sqlite cache.

<img src="https://github.com/opencybersecurityalliance/kestrel-lang/assets/5579397/38387d7e-2288-4282-9eaf-6ef943f9defb" alt="drawing" width="550"/></br>

Nested SQL generated:
```
SELECT name,
       pid
FROM
  (SELECT *
   FROM
     (SELECT *
      FROM "4a0556697e314809849db3e26a532d10") AS anon_2
   WHERE pid IN
       (SELECT anon_3.pid
        FROM
          (SELECT pid
           FROM
             (SELECT *
              FROM
                (SELECT *
                 FROM "4a0556697e314809849db3e26a532d10") AS anon_5
              WHERE name = 'firefox.exe'
                OR name = 'chrome.exe') AS anon_4) AS anon_3)
     AND name IN
       (SELECT anon_6.name
        FROM
          (SELECT name
           FROM
             (SELECT *
              FROM
                (SELECT *
                 FROM "4a0556697e314809849db3e26a532d10") AS anon_8
              WHERE pid IN (123,
                            201)) AS anon_7) AS anon_6)) AS anon_1
```

Indentation provided by https://sqlformat.org/