### PR TITLE
fix the interface type bug for Kestrel 2

### DIFF
--- a/packages-nextgen/kestrel_core/src/kestrel/cache/base.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/cache/base.py
@@ -16,8 +16,8 @@ class AbstractCache(AbstractInterface, MutableMapping):
         - evaluate_graph()
     """
 
-    @property
-    def schemes(self):
+    @staticmethod
+    def schemes() -> Iterable[str]:
         return [CACHE_INTERFACE_IDENTIFIER]
 
     @abstractmethod

--- a/packages-nextgen/kestrel_core/src/kestrel/interface/base.py
+++ b/packages-nextgen/kestrel_core/src/kestrel/interface/base.py
@@ -52,9 +52,11 @@ class AbstractInterface(ABC):
             except:
                 raise InvalidSerializedDatasourceInterfaceCacheCatalog()
 
-    @property
+    # Python 3.13 will drop chain of @classmethod and @property
+    # use @staticmethod instead (cannot make it a property)
+    @staticmethod
     @abstractmethod
-    def schemes(self) -> Iterable[str]:
+    def schemes() -> Iterable[str]:
         """The schemes to specify the interface
 
         Each scheme should be defined as ``("_"|LETTER) ("_"|LETTER|DIGIT)*``

--- a/packages-nextgen/kestrel_core/tests/test_interface_datasource_codegen_dataframe.py
+++ b/packages-nextgen/kestrel_core/tests/test_interface_datasource_codegen_dataframe.py
@@ -56,7 +56,7 @@ def test_evaluate_ProjectAttrs():
 
 
 def test_evaluate_Construct_Filter_ProjectAttrs():
-    stmt = """
+    stmt = r"""
 proclist = NEW process [ {"name": "cmd.exe", "pid": 123}
                        , {"name": "explorer.exe", "pid": 99}
                        , {"name": "firefox.exe", "pid": 201}

--- a/packages-nextgen/kestrel_core/tests/test_session.py
+++ b/packages-nextgen/kestrel_core/tests/test_session.py
@@ -88,13 +88,13 @@ EXPLAIN chrome
 def test_multi_interface_explain():
 
     class DataLake(SqliteCache):
-        @property
-        def schemes(self):
+        @staticmethod
+        def schemes():
             return ["datalake"]
 
     class Gateway(SqliteCache):
-        @property
-        def schemes(self):
+        @staticmethod
+        def schemes():
             return ["gateway"]
 
     extra_db = []

--- a/packages-nextgen/kestrel_interface_opensearch/src/kestrel_interface_opensearch/interface.py
+++ b/packages-nextgen/kestrel_interface_opensearch/src/kestrel_interface_opensearch/interface.py
@@ -90,8 +90,8 @@ class OpenSearchInterface(AbstractInterface):
                 )
                 self.conns[name] = client
 
-    @property
-    def schemes(self):
+    @staticmethod
+    def schemes() -> Iterable[str]:
         return ["opensearch"]
 
     def store(


### PR DESCRIPTION
You found a bug of my typing hint @pcoccoli 

The type for parameters of `_guard_scheme_conflict()` is actually class, not an instantiated object. Of course, class is also object in Python, and we can attest its class, i.e., a metaclass.

Other two bugs fixed:
1. I should use raw string in `test_interface_datasource_codegen_dataframe.py` as there is a raw string with `\w` in the Kestrel huntflow.
2. We will use `interface.schemes()` in the future since chaining `@classmethod` and `@property` will be dropped in Python 3.13.