### PR TITLE
Extend Entity Mapping

### DIFF
--- a/packages/kestrel_core/src/kestrel/config/kestrel.yaml
+++ b/packages/kestrel_core/src/kestrel/config/kestrel.yaml
@@ -11,6 +11,8 @@ debug:
 # always provide a list as identifiers even it is a single identifier
 # if multiple attributes are specified, logic AND will be added in between
 entity_identifier:
+  endpoint:
+    - uid
   file: # "hashes[?algorithm_id == 3]" # sha256
     - name
     - endpoint.uid
@@ -19,8 +21,6 @@ entity_identifier:
   process:
     - uid
     - endpoint.uid
-  endpoint:
-    - uid
   src_endpoint:
     - ip
     - port
@@ -30,4 +30,6 @@ entity_identifier:
   certificate:
     - serial_number
   user:
+    - uid
+  email:
     - uid

--- a/packages/kestrel_core/src/kestrel/config/kestrel.yaml
+++ b/packages/kestrel_core/src/kestrel/config/kestrel.yaml
@@ -8,22 +8,26 @@ debug:
   cache_directory_path: "~/kestrel-debug-session" # put in user's home directory by default
 
 # default identifier attribute(s) of an entity across all datasource interfaces
+# always provide a list as identifiers even it is a single identifier
 # if multiple attributes are specified, logic AND will be added in between
-# each datasource interface config could have the same section to override this
 entity_identifier:
   file: # "hashes[?algorithm_id == 3]" # sha256
     - name
     - endpoint.uid
-  group: uid
+  group:
+    - uid
   process:
     - uid
     - endpoint.uid
-  endpoint: uid
+  endpoint:
+    - uid
   src_endpoint:
     - ip
     - port
   dst_endpoint:
     - ip
     - port
-  certificate: serial_number
-  user: uid
+  certificate:
+    - serial_number
+  user:
+    - uid

--- a/packages/kestrel_core/src/kestrel/config/kestrel.yaml
+++ b/packages/kestrel_core/src/kestrel/config/kestrel.yaml
@@ -11,11 +11,14 @@ debug:
 # if multiple attributes are specified, logic AND will be added in between
 # each datasource interface config could have the same section to override this
 entity_identifier:
-  file: "hashes[?algorithm_id == 3]" # sha256
+  file: # "hashes[?algorithm_id == 3]" # sha256
+    - name
+    - endpoint.uid
   group: uid
-  process: uid
-  endpoint: ip
-  device: ip
+  process:
+    - uid
+    - endpoint.uid
+  endpoint: uid
   src_endpoint:
     - ip
     - port

--- a/packages/kestrel_core/src/kestrel/config/utils.py
+++ b/packages/kestrel_core/src/kestrel/config/utils.py
@@ -6,7 +6,7 @@ from typeguard import typechecked
 from typing import Mapping, Union
 
 from kestrel.utils import update_nested_dict, load_data_file
-from kestrel.exceptions import InvalidYamlInConfig
+from kestrel.exceptions import InvalidYamlInConfig, InvalidKestrelConfig
 
 CONFIG_DIR_DEFAULT = Path.home() / ".config" / "kestrel"
 CONFIG_PATH_DEFAULT = CONFIG_DIR_DEFAULT / "kestrel.yaml"
@@ -70,4 +70,11 @@ def load_kestrel_config() -> Mapping:
     config_user = load_user_config(CONFIG_PATH_ENV_VAR, CONFIG_PATH_DEFAULT)
     _logger.debug(f"User configuration loaded: {config_user}")
     _logger.debug(f"Updating default config with user config...")
-    return update_nested_dict(config_default, config_user)
+    full_config = update_nested_dict(config_default, config_user)
+
+    # valid the entity identifier section format
+    for entity, idx in full_config["entity_identifier"].items():
+        if not (isinstance(idx, list) and all((isinstance(x, str) for x in idx))):
+            raise InvalidKestrelConfig(f"Invalid entity_identifier for '{entity}'")
+
+    return full_config

--- a/packages/kestrel_core/src/kestrel/exceptions.py
+++ b/packages/kestrel_core/src/kestrel/exceptions.py
@@ -26,6 +26,10 @@ class InvalidYamlInConfig(KestrelError):
     pass
 
 
+class InvalidKestrelConfig(KestrelError):
+    pass
+
+
 class VariableNotFound(KestrelError):
     pass
 
@@ -121,4 +125,8 @@ class DataSourceError(KestrelError):
 class UnsupportedOperatorError(KestrelError):
     """The data source doesn't support this operator"""
 
+    pass
+
+
+class IncompleteDataMapping(KestrelError):
     pass

--- a/packages/kestrel_core/src/kestrel/mapping/data_model.py
+++ b/packages/kestrel_core/src/kestrel/mapping/data_model.py
@@ -221,9 +221,8 @@ def check_entity_identifier_existence_in_mapping(
         if entity_name in data_model_mapping:
             entity = data_model_mapping[entity_name]
             for idx in ids:
-                idxs = idx.split(".")
                 try:
-                    reduce(lambda x, y: x[y], idxs, entity)
+                    reduce(dict.__getitem__, idx.split("."), entity)
                 except KeyError:
                     raise IncompleteDataMapping(
                         f"Identifier '{idx}' missing in data mapping"

--- a/packages/kestrel_core/src/kestrel/mapping/data_model.py
+++ b/packages/kestrel_core/src/kestrel/mapping/data_model.py
@@ -53,7 +53,22 @@ def _add_attr(obj: dict, key: str, value: str):
 
 
 def reverse_mapping(obj: dict, prefix: str = None, result: dict = None) -> dict:
-    """Reverse the mapping; return native -> OCSF map"""
+    """Reverse the mapping of `obj`
+
+    Newly loaded mapping from disk is OCSF -> native mapping. This function
+    takes in such mapping, and reverse it to native -> OCSF mapping, which can
+    be used by the frontend. The result mapping is flattened.
+
+    To call the function: `reverse_mapping(ocsf_to_native_mapping)`
+
+    Parameters:
+        obj: mapping loaded from disk (OCSF -> native)
+        prefix: key path to `obj`; used by the recursive function itself
+        result: intermediate result mapping; used by the recursive function itself
+
+    Returns:
+        native -> OCSF mapping
+    """
     if result is None:
         result = {}
     for k, v in obj.items():

--- a/packages/kestrel_core/src/kestrel/mapping/entityattribute/ecs.yaml
+++ b/packages/kestrel_core/src/kestrel/mapping/entityattribute/ecs.yaml
@@ -1,5 +1,16 @@
+# endpoint: see https://schema.ocsf.io/1.1.0/objects/endpoint
+endpoint: &endpoint
+    uid: host.id
+    domain: host.domain
+    name: host.name
+    hostname: host.hostname
+    ip: host.ip
+    mac: host.mac
+
+
 # https://schema.ocsf.io/1.1.0/objects/file
 file:
+    endpoint: *endpoint
     accessed_time: file.accessed
     attributes: file.attributes
     created_time: file.created
@@ -49,6 +60,7 @@ group:
 
 # https://schema.ocsf.io/1.1.0/objects/process
 process:
+    endpoint: *endpoint
     cmd_line: process.command_line
     name: process.name
     pid: process.pid
@@ -141,30 +153,6 @@ src_endpoint: &src_ref
         - source.port
 
 
-# endpoint: see https://schema.ocsf.io/1.1.0/objects/endpoint
-endpoint:
-    domain:
-        - client.domain
-        - source.domain
-        - server.domain
-        - destination.domain
-    hostname:
-        - client.domain
-        - source.domain
-        - server.domain
-        - destination.domain
-    ip:
-        - client.ip
-        - source.ip
-        - server.ip
-        - destination.ip
-    mac:
-        - client.mac
-        - source.mac
-        - server.mac
-        - destination.mac
-
-
 # dst_endpoint: see https://schema.ocsf.io/1.1.0/objects/endpoint
 dst_endpoint: &dst_ref
     domain:
@@ -225,7 +213,6 @@ certificate:
     version: x509.version_number
     issuer: x509.issuer.distinguished_name
     subject: x509.subject.distinguished_name
-    #uid:
 
 
 # https://schema.ocsf.io/1.1.0/objects/user
@@ -242,3 +229,15 @@ network_activity:
     src_endpoint: *src_ref
     dst_endpoint: *dst_ref
     traffic: *traffic
+
+
+# https://schema.ocsf.io/1.2.0/objects/win/reg_key?extensions=win
+reg_key:
+    endpoint: *endpoint
+    path: registry.key
+
+
+# https://schema.ocsf.io/1.2.0/objects/win/reg_value?extensions=win
+reg_value:
+    endpoint: *endpoint
+    path: registry.value

--- a/packages/kestrel_core/src/kestrel/mapping/entityattribute/ecs.yaml
+++ b/packages/kestrel_core/src/kestrel/mapping/entityattribute/ecs.yaml
@@ -236,6 +236,16 @@ network_activity:
     traffic: *traffic
 
 
+# https://schema.ocsf.io/1.2.0/objects/email
+email:
+    uid: email.message_id
+    from: email.from.address
+    to: email.to.address
+    reply_to: email.reply_to.address
+    cc: email.cc.address
+    subject: email.subject
+
+
 # https://schema.ocsf.io/1.2.0/objects/win/reg_key?extensions=win
 reg_key:
     endpoint: *endpoint

--- a/packages/kestrel_core/src/kestrel/mapping/entityattribute/ecs.yaml
+++ b/packages/kestrel_core/src/kestrel/mapping/entityattribute/ecs.yaml
@@ -8,6 +8,14 @@ endpoint: &endpoint
     mac: host.mac
 
 
+# https://schema.ocsf.io/1.1.0/objects/user
+user:
+    domain: user.domain
+    full_name: user.full_name
+    name: user.name
+    uid: user.id
+
+
 # https://schema.ocsf.io/1.1.0/objects/file
 file:
     endpoint: *endpoint
@@ -132,6 +140,11 @@ process:
                 native_op: LIKE
                 native_value: posixpath_startswith
                 ocsf_value: dirname
+    user:
+        domain: process.user.domain
+        full_name: process.user.full_name
+        name: process.user.name
+        uid: process.user.id
 
 
 # src_endpoint: see https://schema.ocsf.io/1.1.0/objects/endpoint
@@ -213,14 +226,6 @@ certificate:
     version: x509.version_number
     issuer: x509.issuer.distinguished_name
     subject: x509.subject.distinguished_name
-
-
-# https://schema.ocsf.io/1.1.0/objects/user
-user:
-    domain: user.domain
-    full_name: user.full_name
-    name: user.name
-    uid: user.id
 
 
 # https://schema.ocsf.io/1.1.0/classes/network_activity

--- a/packages/kestrel_core/src/kestrel/mapping/entityattribute/stix.yaml
+++ b/packages/kestrel_core/src/kestrel/mapping/entityattribute/stix.yaml
@@ -1,3 +1,5 @@
+# Not updated for extended endpoint mapping (per process/file)
+
 # https://schema.ocsf.io/1.1.0/objects/file
 file:
     name: file:name
@@ -141,3 +143,13 @@ user:
     name: user-account:account_login
     type: user-account:account_type
     uid: user-account:user_id
+
+
+# https://schema.ocsf.io/1.2.0/objects/win/reg_key?extensions=win
+reg_key:
+    path: windows-registry-key.key
+
+
+# https://schema.ocsf.io/1.2.0/objects/win/reg_value?extensions=win
+reg_value:
+    path: windows-registry-key.value.data

--- a/packages/kestrel_core/src/kestrel/mapping/entityname/alias.yaml
+++ b/packages/kestrel_core/src/kestrel/mapping/entityname/alias.yaml
@@ -3,3 +3,10 @@ activity: base_event
 device: endpoint
 registrykey: reg_key
 registryvalue: reg_value
+
+# Extended mapping to cover special field in OCSF activity
+actor.user: user
+# To simplify mapping, we do not cover parent process in actor.process
+# - This semantic only appear in Process Activity [1007], please use `process.parent_process` to specify in this case
+# - This works in Activity besides Process Activity [1007]
+actor.process: process

--- a/packages/kestrel_core/src/kestrel/mapping/entityname/alias.yaml
+++ b/packages/kestrel_core/src/kestrel/mapping/entityname/alias.yaml
@@ -1,3 +1,5 @@
 event: base_event
 activity: base_event
-
+device: endpoint
+registrykey: reg_key
+registryvalue: reg_value

--- a/packages/kestrel_core/tests/test_mapping_data_model.py
+++ b/packages/kestrel_core/tests/test_mapping_data_model.py
@@ -2,6 +2,8 @@ import pytest
 
 import pandas as pd
 
+from kestrel.exceptions import IncompleteDataMapping
+from kestrel.config.utils import load_kestrel_config
 from kestrel.mapping.data_model import (
     load_default_mapping,
     reverse_mapping,
@@ -9,6 +11,7 @@ from kestrel.mapping.data_model import (
     translate_comparison_to_ocsf,
     translate_dataframe,
     translate_projection_to_native,
+    check_entity_identifier_existence_in_mapping,
 )
 
 
@@ -84,6 +87,14 @@ WINLOGBEAT_MAPPING = {
     "src_endpoint": {
         "ip": "winlog.event_data.SourceIp",
         "port": "winlog.event_data.SourcePort"
+    }
+}
+
+
+# Mapping for testing missing identifier
+INCOMPLETE_MAPPING = {
+    "process": {
+        "pid": "process.pid"
     }
 }
 
@@ -205,3 +216,9 @@ def test_translate_dataframe():  #TODO: more testing here
     dmm = load_default_mapping("ecs")
     df = translate_dataframe(df, dmm["process"])
     #TODO:assert df["file.name"].iloc[0] == "cmd.exe"
+
+
+def test_incomplete_mapping_no_identifier():
+    identifier_config = load_kestrel_config()["entity_identifier"]
+    with pytest.raises(IncompleteDataMapping):
+        check_entity_identifier_existence_in_mapping(INCOMPLETE_MAPPING, identifier_config)

--- a/packages/kestrel_interface_opensearch/tests/test_config.py
+++ b/packages/kestrel_interface_opensearch/tests/test_config.py
@@ -52,4 +52,4 @@ def test_load_config(tmp_path):
     assert read_config.connections["localhost"].url == config["connections"]["localhost"]["url"]
     assert read_config.datasources["some_ds"].index_pattern == config["datasources"]["some_ds"]["index_pattern"]
     assert read_config.datasources["some_ds"].data_model_map["some.field"] == "other.field"
-    assert read_config.datasources["some_ds"].entity_identifier["process"] == "uid"
+    assert read_config.datasources["some_ds"].entity_identifier["process"] == ['uid', 'endpoint.uid']

--- a/packages/kestrel_interface_opensearch/tests/test_config.py
+++ b/packages/kestrel_interface_opensearch/tests/test_config.py
@@ -52,4 +52,3 @@ def test_load_config(tmp_path):
     assert read_config.connections["localhost"].url == config["connections"]["localhost"]["url"]
     assert read_config.datasources["some_ds"].index_pattern == config["datasources"]["some_ds"]["index_pattern"]
     assert read_config.datasources["some_ds"].data_model_map["some.field"] == "other.field"
-    assert read_config.datasources["some_ds"].entity_identifier["process"] == ['uid', 'endpoint.uid']

--- a/packages/kestrel_interface_sqlalchemy/src/kestrel_interface_sqlalchemy/config.py
+++ b/packages/kestrel_interface_sqlalchemy/src/kestrel_interface_sqlalchemy/config.py
@@ -10,7 +10,10 @@ from kestrel.config.utils import (
     load_kestrel_config,
 )
 from kestrel.exceptions import InterfaceNotConfigured
-from kestrel.mapping.data_model import load_default_mapping
+from kestrel.mapping.data_model import (
+    load_default_mapping,
+    check_entity_identifier_existence_in_mapping,
+)
 
 
 PROFILE_PATH_DEFAULT = CONFIG_DIR_DEFAULT / "sqlalchemy.yaml"
@@ -38,6 +41,11 @@ class DataSource(DataClassJSONMixin):
             # Default to the built-in ECS mapping
             self.data_model_map = load_default_mapping("ecs")  # FIXME: need a default?
 
+        kestrel_config = load_kestrel_config()
+        check_entity_identifier_existence_in_mapping(
+            self.data_model_map, kestrel_config["entity_identifier"]
+        )
+
 
 @dataclass
 class Config(DataClassJSONMixin):
@@ -54,13 +62,6 @@ def load_config():
         interface_config = Config(
             **load_user_config(PROFILE_PATH_ENV_VAR, PROFILE_PATH_DEFAULT)
         )
-
-        # load default entity identifier from main Kestrel config
-        kestrel_config = load_kestrel_config()
-        for ds in interface_config.datasources.values():
-            if not ds.entity_identifier:
-                ds.entity_identifier = kestrel_config["entity_identifier"]
-
         return interface_config
     except TypeError:
         raise InterfaceNotConfigured()

--- a/packages/kestrel_interface_sqlalchemy/tests/test_config.py
+++ b/packages/kestrel_interface_sqlalchemy/tests/test_config.py
@@ -31,7 +31,6 @@ def test_load_config_w_default_map(tmp_path):
     os.environ[PROFILE_PATH_ENV_VAR] = str(config_file)
     read_config = load_config()
     assert read_config.datasources["cloud_table"].data_model_map["process"]["name"] == "process.name"
-    assert read_config.datasources["cloud_table"].entity_identifier["process"] == ['uid', 'endpoint.uid']
 
 
 def test_load_config(tmp_path):
@@ -51,7 +50,6 @@ def test_load_config(tmp_path):
                 "timestamp": "eventTime",
                 "timestamp_format": "%Y-%m-%d %H:%M:%S.%f",
                 "data_model_map": str(tmp_path / "mapping.yaml"),
-                "entity_identifier": "eid.yaml"
             }
         }
     }
@@ -72,4 +70,3 @@ def test_load_config(tmp_path):
     assert read_config.datasources["cloud_table"].timestamp == config["datasources"]["cloud_table"]["timestamp"]
     assert read_config.datasources["cloud_table"].table == config["datasources"]["cloud_table"]["table"]
     assert read_config.datasources["cloud_table"].data_model_map["some.field"] == "other.field"
-    assert read_config.datasources["cloud_table"].entity_identifier["process"] == "pid"

--- a/packages/kestrel_interface_sqlalchemy/tests/test_config.py
+++ b/packages/kestrel_interface_sqlalchemy/tests/test_config.py
@@ -8,6 +8,7 @@ from kestrel_interface_sqlalchemy.config import (
     load_config,
 )
 
+
 def test_load_config_w_default_map(tmp_path):
     config = {
         "connections": {
@@ -30,7 +31,8 @@ def test_load_config_w_default_map(tmp_path):
     os.environ[PROFILE_PATH_ENV_VAR] = str(config_file)
     read_config = load_config()
     assert read_config.datasources["cloud_table"].data_model_map["process"]["name"] == "process.name"
-    assert read_config.datasources["cloud_table"].entity_identifier["process"] == "uid"
+    assert read_config.datasources["cloud_table"].entity_identifier["process"] == ['uid', 'endpoint.uid']
+
 
 def test_load_config(tmp_path):
     config = {


### PR DESCRIPTION
1. Add `reg_key` and `reg_value` mapping for ECS
2. Extend `process` and `file` with `endpoint.*` in ECS mapping
3. Add identifier verification for mapping
4. Fix #523 
5. Remove per-interface identifier configuration to support identifier generation in front-end
6. Add `actor.process` and `actor.user` as entity alias
7. Add basic email mapping for ECS